### PR TITLE
update estimate_category standardization

### DIFF
--- a/R/transform_estimates.R
+++ b/R/transform_estimates.R
@@ -87,9 +87,13 @@ transform_estimates <- function(dwg,
                     dplyr::mutate(
                       #Make BSS outputs match PE
                       estimate_category = dplyr::case_when(
+                        #stratum
                         .data$estimate_category == "C_daily" ~ "catch",
                         .data$estimate_category == "E_daily" ~ "effort",
                         .data$estimate_category == "CPUE_daily" ~ "CPUE",
+                        #total
+                        .data$estimate_category == "C_sum" ~ "catch",
+                        .data$estimate_category == "E_sum" ~ "effort",
                         TRUE ~ .data$estimate_category
                       ),
                       #apply snake_case to estimate_type values


### PR DESCRIPTION
Evan noted in issue #2 that the estimate_category field of the model_estimates_total table in the creel database contained unexpected values of "C_sum" and "E_sum" instead of the expected standardized naming "catch" and "effort". This PR adds C_sum and E_sum to a section of the transform_estimates function to correct this.