### PR TITLE
Update function to include db connection type. Uses ODBC as default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,7 @@ Imports:
     tidyr,
     glue,
     rstan,
-    odbc,
-    withr
+    odbc
 Suggests:
     ggplot2,
     knitr,

--- a/man/establish_db_con.Rd
+++ b/man/establish_db_con.Rd
@@ -11,11 +11,11 @@ establish_db_con(
 )
 }
 \arguments{
+\item{conn_type}{Character input denoting either "odbc" or "config" connection type.}
+
 \item{dsn}{Character string denoting the ODBC domain service name (DSN) to connect to.}
 
 \item{config_path}{File path location of the local 'config.yml' file.}
-
-\item{type}{Character input denoting either "odbc" or "config" connection type.}
 }
 \value{
 A \code{DBI} connection to a PostgreSQL database management system. Recommend that this object be named "con".


### PR DESCRIPTION
This PR adds functionality to establish_db_con() with the addition of the conn_type argument. This argument defaults to an OBDC connection with a DSN called "creel_estimates", though these can be supplied. The conn_type= "config" option still allows for a local database configuration file.