### PR TITLE
Patch ETL functions to prevent converting Rmd document to json

### DIFF
--- a/R/export_estimates.R
+++ b/R/export_estimates.R
@@ -25,11 +25,6 @@ export_estimates <- function(params, analysis_lut, creel_estimates, conn = NULL)
     #convert metadata to json. Automatically added to analysis_lut
     analysis_lut <- json_conversion(type = "r_session", params, analysis_lut)
 
-    if (interactive() && rstudioapi::isAvailable()) {
-      #only performed interactively, not programatically
-      analysis_lut <- json_conversion(type = "script", params, analysis_lut)
-    }
-
     # Connect to database if connection not supplied in argument
     if (is.null(conn)) {
     con <- establish_db_con()

--- a/R/json_conversion.R
+++ b/R/json_conversion.R
@@ -23,46 +23,46 @@ json_conversion <- function(type, params, analysis_lut) {
 
   #convert items to json format based on type
   if (type == "script") {
-
-    #save local script to archive any alterations from template script
-    # Only save document if running interactively in RStudio
-    if (interactive() && rstudioapi::isAvailable()) {
-      tryCatch({
-        rstudioapi::documentSave()
-        cat("\nLocal analysis script saved.")
-      }, error = function(e) {
-        warning("Could not save document via RStudio API: ", e$message)
-        cat("\nSkipping document save (not in RStudio environment).")
-      })
-    } else {
-      cat("\nSkipping document save (not in interactive RStudio session).")
-    }
-
-    #locate script location on CreelEstimates local repository clone
-    analysis_script <- readLines(paste0(
-      getwd(), "/fishery_analyses/", params$project_name, "/", params$fishery_name,
-      "/", "fw_creel_", params$fishery_name, ".Rmd"
-    ))
-
-    #convert to JSON format and validate
-    json_script <- jsonlite::toJSON(analysis_script, pretty = TRUE)
-
-    cat("\nLocal script read and converted to JSON format.")
-
-    valid <- jsonlite::validate(json_script)
-
-    if(valid) { #if TRUE
-
-      cat("\nJSON valid... adding `analysis_json` to analysis_lut.")
-
-      #add to analysis look up table
-      analysis_lut <- analysis_lut |>  dplyr::mutate(analysis_json = json_script)
-
-      return(analysis_lut)
-
-    } else {
-      warning("\nJSON format not valid! JSON representation of local script not added to analysis_lut.")
-    }
+#
+#     #save local script to archive any alterations from template script
+#     # Only save document if running interactively in RStudio
+#     if (interactive() && rstudioapi::isAvailable()) {
+#       tryCatch({
+#         rstudioapi::documentSave()
+#         cat("\nLocal analysis script saved.")
+#       }, error = function(e) {
+#         warning("Could not save document via RStudio API: ", e$message)
+#         cat("\nSkipping document save (not in RStudio environment).")
+#       })
+#     } else {
+#       cat("\nSkipping document save (not in interactive RStudio session).")
+#     }
+#
+#     #locate script location on CreelEstimates local repository clone
+#     analysis_script <- readLines(paste0(
+#       getwd(), "/fishery_analyses/", params$project_name, "/", params$fishery_name,
+#       "/", "fw_creel_", params$fishery_name, ".Rmd"
+#     ))
+#
+#     #convert to JSON format and validate
+#     json_script <- jsonlite::toJSON(analysis_script, pretty = TRUE)
+#
+#     cat("\nLocal script read and converted to JSON format.")
+#
+#     valid <- jsonlite::validate(json_script)
+#
+#     if(valid) { #if TRUE
+#
+#       cat("\nJSON valid... adding `analysis_json` to analysis_lut.")
+#
+#       #add to analysis look up table
+#       analysis_lut <- analysis_lut |>  dplyr::mutate(analysis_json = json_script)
+#
+#       return(analysis_lut)
+#
+#     } else {
+#       warning("\nJSON format not valid! JSON representation of local script not added to analysis_lut.")
+#     }
   }
   if (type == "regulations") {
 


### PR DESCRIPTION
Recently I have been working on a script for rendering multiple analyses at a time, which can be initiated by Microsoft Task Scheduler. Evan shared copies of scripts he had previously written to create a task using taskscheduleR package and batch render scripts. During the testing and further development of this process I discovered that when R is called from the command prompt (i.e., headless mode) an error would be produced while attempted to upload model estimates to the creel database. The json conversion script calls "rstudioapi::documentSave()" to save the active script to preserve any recent edits before converting to a json text string. However, when run in headless mode there is no RStudio api to call and the entire rendering would fail.

This patch silences the feature to convert a given Rmd to json, which was previously then stored in the analysis_lut. The ability to run scheduled models is a higher priority at this time than storing the script file as metadata in the database. Future updates may reincorporate this feature.