### PR TITLE
fix: default establish_db_con to config/RPostgres for performance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: creelutils
 Title: Utility Functions for Interacting with Freshwater Creel Data
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Colt", "Holley", email = "colt.holley@dfw.wa.gov", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-4172-4331")),
     person("Kale", "Bentley", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# creelutils 0.1.1
+
+* `establish_db_con()`: changed default `conn_type` from `"odbc"` to `"config"` 
+  to use the faster `RPostgres` driver by default. ODBC is still available via 
+  `conn_type = "odbc"`. Note: password prompt from config will block execution in 
+  non-interactive (automated) sessions.
+
 # creelutils 0.1.0
 
 * Early development version. Putting the package together with basic structure, documentation, GitHub actions, etc.

--- a/R/establish_db_con.R
+++ b/R/establish_db_con.R
@@ -1,14 +1,17 @@
 #' Establish database connection
 #'
-#' @description Establishes a connection to the WDFW PostgreSQL database. This process requires either a configured ODBC DSN or a local `config.yml` file.
-#' @param conn_type Character input denoting either "odbc" or "config" connection type.
+#' @description Establishes a connection to the WDFW PostgreSQL database.
+#' Requires either a  local `config.yml` file (default) or a configured ODBC DSN.
+#' The config path uses driver from the `RPostgres` package and is preferred for performance, particularly during build database writes.
+#' **Note:** when called in a non-interactive session (scheduled render or automated script), the password prompt will block execution.
+#' @param conn_type `"config"` (default) uses a local `config.yml` + `RPostgres`; `"odbc"` uses a system-configured DSN.
 #' @param dsn Character string denoting the ODBC domain service name (DSN) to connect to.
 #' @param config_path File path location of the local 'config.yml' file.
 #' @family internal_data
 #' @return A `DBI` connection to a PostgreSQL database management system. Recommend that this object be named "con".
 #' @export
 establish_db_con<- function(
-    conn_type = c("odbc", "config"),
+    conn_type = c("config", "odbc"), # default order changed in version 0.1.1
     dsn = "creel_estimates",
     config_path = "config.yml"
   ) {

--- a/man/establish_db_con.Rd
+++ b/man/establish_db_con.Rd
@@ -5,13 +5,13 @@
 \title{Establish database connection}
 \usage{
 establish_db_con(
-  conn_type = c("odbc", "config"),
+  conn_type = c("config", "odbc"),
   dsn = "creel_estimates",
   config_path = "config.yml"
 )
 }
 \arguments{
-\item{conn_type}{Character input denoting either "odbc" or "config" connection type.}
+\item{conn_type}{\code{"config"} (default) uses a local \code{config.yml} + \code{RPostgres}; \code{"odbc"} uses a system-configured DSN.}
 
 \item{dsn}{Character string denoting the ODBC domain service name (DSN) to connect to.}
 
@@ -21,7 +21,10 @@ establish_db_con(
 A \code{DBI} connection to a PostgreSQL database management system. Recommend that this object be named "con".
 }
 \description{
-Establishes a connection to the WDFW PostgreSQL database. This process requires either a configured ODBC DSN or a local \code{config.yml} file.
+Establishes a connection to the WDFW PostgreSQL database.
+Requires either a  local \code{config.yml} file (default) or a configured ODBC DSN.
+The config path uses driver from the \code{RPostgres} package and is preferred for performance, particularly during build database writes.
+\strong{Note:} when called in a non-interactive session (scheduled render or automated script), the password prompt will block execution.
 }
 \seealso{
 Other internal_data: 


### PR DESCRIPTION
- Flip conn_type default from 'odbc' to 'config'
- ODBC still available via conn_type = 'odbc'
- Add note re: password prompt blocking automated/non-interactive sessions
- Bump version to 0.1.1, update NEWS.md