### PR TITLE
fix: relocate config.yml file to ~/.config/creelutils 

### DIFF
--- a/R/connect_creel_db.R
+++ b/R/connect_creel_db.R
@@ -21,7 +21,7 @@
 #' @param config_path Path to the `config.yml` file containing server
 #'   connection details. When `NULL` (the default), checks the
 #'   `CREELUTILS_CONFIG_PATH` environment variable first, then falls back to
-#'   `rappdirs::user_config_dir("creelutils")`.
+#'   `C:/Users/user-name/.config/creelutils`.
 #'
 #' @return A `DBI` connection object to a PostgreSQL database. It is
 #'   conventional to assign this to `con`:

--- a/R/connect_creel_db.R
+++ b/R/connect_creel_db.R
@@ -18,8 +18,10 @@
 #' @param db_env `"prod"` (default) connects to the production database.
 #'   `"test"` connects to the test database. Credentials are the same for both;
 #'   write permissions are more restricted on the test server.
-#' @param config_path Path to the local `config.yml` file containing server
-#'   connection details. Defaults to `"config.yml"` in the working directory.
+#' @param config_path Path to the `config.yml` file containing server
+#'   connection details. When `NULL` (the default), checks the
+#'   `CREELUTILS_CONFIG_PATH` environment variable first, then falls back to
+#'   `rappdirs::user_config_dir("creelutils")`.
 #'
 #' @return A `DBI` connection object to a PostgreSQL database. It is
 #'   conventional to assign this to `con`:
@@ -43,17 +45,31 @@
 #' }
 connect_creel_db <- function(
     db_env = c("prod", "test"),
-    config_path = "config.yml"
+    config_path = NULL
 ) {
   db_env <- match.arg(db_env)
+
+  # Connection priority
+  # 1 - config_path arg supplied, 2 - env var for GH Actions workflow, 3 - config.yml file in .config dotfolder
+  if (is.null(config_path)) {
+    env_path <- Sys.getenv("CREELUTILS_CONFIG_PATH", unset = "")
+    config_path <- if (nzchar(env_path)) {
+      env_path
+    } else {
+      file.path(Sys.getenv("USERPROFILE", unset = Sys.getenv("HOME")), ".config", "creelutils", "config.yml")
+    }
+  }
 
   # -- 1. Read and validate config --------------------------------------------
 
   if (!file.exists(config_path)) {
     cli::cli_abort(c(
       "Config file not found at {.path {config_path}}.",
-      "i" = "Ensure {.file config.yml} exists in your working directory, or
-             supply the correct path via {.arg config_path}."
+      "i" = "Place your {.file config.yml} in
+             {.path ~/.config/creelutils/},
+             or supply the path via {.arg config_path}.",
+      "i" = "You can also set the {.envvar CREELUTILS_CONFIG_PATH} environment
+             variable."
     ))
   }
 

--- a/man/connect_creel_db.Rd
+++ b/man/connect_creel_db.Rd
@@ -4,15 +4,17 @@
 \alias{connect_creel_db}
 \title{Connect to the WDFW freshwater creel database}
 \usage{
-connect_creel_db(db_env = c("prod", "test"), config_path = "config.yml")
+connect_creel_db(db_env = c("prod", "test"), config_path = NULL)
 }
 \arguments{
 \item{db_env}{\code{"prod"} (default) connects to the production database.
 \code{"test"} connects to the test database. Credentials are the same for both;
 write permissions are more restricted on the test server.}
 
-\item{config_path}{Path to the local \code{config.yml} file containing server
-connection details. Defaults to \code{"config.yml"} in the working directory.}
+\item{config_path}{Path to the \code{config.yml} file containing server
+connection details. When \code{NULL} (the default), checks the
+\code{CREELUTILS_CONFIG_PATH} environment variable first, then falls back to
+\code{rappdirs::user_config_dir("creelutils")}.}
 }
 \value{
 A \code{DBI} connection object to a PostgreSQL database. It is

--- a/man/connect_creel_db.Rd
+++ b/man/connect_creel_db.Rd
@@ -14,7 +14,7 @@ write permissions are more restricted on the test server.}
 \item{config_path}{Path to the \code{config.yml} file containing server
 connection details. When \code{NULL} (the default), checks the
 \code{CREELUTILS_CONFIG_PATH} environment variable first, then falls back to
-\code{rappdirs::user_config_dir("creelutils")}.}
+\verb{C:/Users/user-name/.config/creelutils}.}
 }
 \value{
 A \code{DBI} connection object to a PostgreSQL database. It is


### PR DESCRIPTION
Updates `connect_creel_db()` to rely on config file stored in a centralized location on a users computer, rather than requiring a separate config file in each working directory that calls this function.

One time per user, the config.yml file will need to be placed in C:/Users/user-name/.config/creelutils/.