### PR TITLE
feature: add lazy data connections to internal_data family of functions

### DIFF
--- a/R/fetch_db_table.R
+++ b/R/fetch_db_table.R
@@ -5,7 +5,7 @@
 #' Note: If the 'filter' argument contains a "catch_group" component, the value provided will be parsed into component fields. For example, "Chinook_Adult_AD_Released" is translated to "species_name = 'Chinook', life_stage_name = 'Adult', fin_mark_desc = 'Adclip clip + No other external marks', fate_name = 'Released'".
 #'
 #' @family internal_data
-#' @param con A valid connection to the WDFW PostgreSQL database. @seealso [establish_db_con()]
+#' @param conn A valid connection to the WDFW PostgreSQL database. @seealso [connect_creel_db()]
 #' @param schema The database schema of interest. Most freshwater creel tasks use the "creel" schema.
 #' @param table The table or view within the database schema that is to be queried.
 #' @param filter A `dplyr` style filter which may contain one or more elements. See Examples section for more information.
@@ -34,10 +34,19 @@
 #'   )
 #' }
 
-fetch_db_table <- function(con, schema, table, filter = NULL, show_query = FALSE) {
-  # check connection to database
-  if(!DBI::dbIsValid(con)) {
-    stop("fetch_db_table error: No database connection provided.")
+fetch_db_table <- function(conn = NULL, schema, table, filter = NULL, show_query = FALSE) {
+
+  if (!is.null(conn) && !inherits(conn, "DBIConnection")) {
+    cli::cli_abort(c(
+      "{.arg conn} must be a {.cls DBIConnection} object or {.code NULL}.",
+      "i" = "Got an object of class {.cls {class(conn)}}.",
+      "i" = "Did you forget to name {.arg schema} and {.arg table}?"
+    ))
+  }
+  # Establish lazy connection if conn not provided
+  if (is.null(conn) || !DBI::dbIsValid(conn)) {
+    conn <- connect_creel_db()
+    on.exit(DBI::dbDisconnect(conn), add = TRUE)
   }
 
   # validate inputs
@@ -46,7 +55,7 @@ fetch_db_table <- function(con, schema, table, filter = NULL, show_query = FALSE
   }
 
   # build query
-  query <- dplyr::tbl(con, dbplyr::in_schema(schema, table))
+  query <- dplyr::tbl(conn, dbplyr::in_schema(schema, table))
 
   # define lookup for mark_status translation
   mark_status_lookup <- c(

--- a/R/fetch_public_helpers.R
+++ b/R/fetch_public_helpers.R
@@ -6,7 +6,9 @@
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' head(fetch_fishery_names(), n = 10)
+#' }
 fetch_fishery_names = function(...){
   if (length(list(...)) > 0) {
     cli::cli_abort("The function {.fn fetch_fishery_names} does not take any arguments. Call it as {.code fetch_fishery_names()} with empty parentheses.")
@@ -32,8 +34,10 @@ fetch_fishery_names = function(...){
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' search_fishery_name("gamefish")
 #' search_fishery_name("Humptulips")
+#' }
 search_fishery_name <- function(fishery_partial){
   grep(fishery_partial, fetch_fishery_names(), ignore.case = T, value = TRUE)
 }

--- a/R/query_helpers.R
+++ b/R/query_helpers.R
@@ -5,11 +5,12 @@
 #'
 #' @return Tibble of fishery names with year, start dates, end dates, and metadata
 #' @export
-fishery_lut <- function(conn) {
+fishery_lut <- function(conn = NULL) {
 
-  # Check database connection
-  if (!DBI::dbIsValid(conn)) {
-    cli::cli_abort("Database connection is not valid or has been closed.")
+  # Establish lazy connection if conn not provided
+  if (is.null(conn) || !DBI::dbIsValid(conn)) {
+    conn <- connect_creel_db()
+    on.exit(DBI::dbDisconnect(conn), add = TRUE)
   }
 
   fetch_db_table(conn, "creel", "fishery_lut")
@@ -24,13 +25,14 @@ fishery_lut <- function(conn) {
 #' @return Tibble of fishery information that includes fishery name, dates, and spatial structure (sections and sites).
 #' @export
 fishery_manager <- function(
-    conn,
+    conn = NULL,
     fishery_name = NULL
   ) {
 
-  # Check database connection
-  if (!DBI::dbIsValid(conn)) {
-    cli::cli_abort("Database connection is not valid or has been closed.")
+  # Establish lazy connection if conn not provided
+  if (is.null(conn) || !DBI::dbIsValid(conn)) {
+    conn <- connect_creel_db()
+    on.exit(DBI::dbDisconnect(conn), add = TRUE)
   }
 
   filter <- NULL
@@ -55,14 +57,15 @@ fishery_manager <- function(
 #' @return Tibble of catch groups of interest for a given fishery.
 #' @export
 fishery_catchgroups <- function(
-    conn,
+    conn = NULL,
     fishery_name = NULL,
     print = FALSE
   ) {
 
-  # Check database connection
-  if (!DBI::dbIsValid(conn)) {
-    cli::cli_abort("Database connection is not valid or has been closed. Reconnect with {.fn connect_creel_db}.")
+  # Establish lazy connection if conn not provided
+  if (is.null(conn) || !DBI::dbIsValid(conn)) {
+    conn <- connect_creel_db()
+    on.exit(DBI::dbDisconnect(conn), add = TRUE)
   }
 
   filter <- NULL
@@ -127,10 +130,12 @@ fishery_catchgroups <- function(
 #' @return A tibble of catch groups from [fishery_catchgroups()] with an appended
 #'   `fish_count` column, filtered to observed catch groups unless `include_zero = TRUE`.
 #' @export
-fishery_catchgroups_obs <- function(conn, data, include_zero = FALSE) {
+fishery_catchgroups_obs <- function(conn = NULL, data, include_zero = FALSE) {
 
-  if (!DBI::dbIsValid(conn)) {
-    cli::cli_abort("Database connection is not valid or has been closed. Reconnect with {.fn connect_creel_db}.")
+  # Establish lazy connection if conn not provided
+  if (is.null(conn) || !DBI::dbIsValid(conn)) {
+    conn <- connect_creel_db()
+    on.exit(DBI::dbDisconnect(conn), add = TRUE)
   }
 
   fishery_name <- unique(data$fishery_manager$fishery_name)
@@ -206,8 +211,13 @@ query_analysis_lut <- function(
     fishery_name = NULL
   ) {
 
-  filter <- NULL
+  # Establish lazy connection if conn not provided
+  if (is.null(conn) || !DBI::dbIsValid(conn)) {
+    conn <- connect_creel_db()
+    on.exit(DBI::dbDisconnect(conn), add = TRUE)
+  }
 
+  filter <- NULL
   if (!is.null(analysis_id)) {
     filter <- glue::glue("analysis_id == '{analysis_id}'")
   } else if (!is.null(fishery_name)) {
@@ -240,6 +250,12 @@ model_estimates <- function(
     ...
   ) {
 
+  # Establish lazy connection if conn not provided
+  if (is.null(conn) || !DBI::dbIsValid(conn)) {
+    conn <- connect_creel_db()
+    on.exit(DBI::dbDisconnect(conn), add = TRUE)
+  }
+
   scale <- match.arg(scale)
   table <- glue::glue("model_estimates_{scale}")
 
@@ -253,7 +269,6 @@ model_estimates <- function(
 
   # Build filters
   filters <- NULL
-
   if (!is.null(analysis_id)) {
     filters <- c(filters, glue::glue("analysis_id == '{analysis_id}'"))
   }

--- a/man/fetch_db_table.Rd
+++ b/man/fetch_db_table.Rd
@@ -47,7 +47,6 @@ c <- fetch_db_table(
 \seealso{
 Other internal_data: 
 \code{\link{connect_creel_db}()},
-\code{\link{fetch_data}()},
 \code{\link{fishery_catchgroups}()},
 \code{\link{fishery_catchgroups_obs}()}
 }

--- a/man/fetch_db_table.Rd
+++ b/man/fetch_db_table.Rd
@@ -4,10 +4,10 @@
 \alias{fetch_db_table}
 \title{Query database tables}
 \usage{
-fetch_db_table(con, schema, table, filter = NULL, show_query = FALSE)
+fetch_db_table(conn = NULL, schema, table, filter = NULL, show_query = FALSE)
 }
 \arguments{
-\item{con}{A valid connection to the WDFW PostgreSQL database. @seealso \code{\link[=establish_db_con]{establish_db_con()}}}
+\item{conn}{A valid connection to the WDFW PostgreSQL database. @seealso \code{\link[=connect_creel_db]{connect_creel_db()}}}
 
 \item{schema}{The database schema of interest. Most freshwater creel tasks use the "creel" schema.}
 
@@ -47,6 +47,7 @@ c <- fetch_db_table(
 \seealso{
 Other internal_data: 
 \code{\link{connect_creel_db}()},
+\code{\link{fetch_data}()},
 \code{\link{fishery_catchgroups}()},
 \code{\link{fishery_catchgroups_obs}()}
 }

--- a/man/fetch_fishery_names.Rd
+++ b/man/fetch_fishery_names.Rd
@@ -16,7 +16,9 @@ Character vector of "fishery_name" values which represent identifiers for a give
 List all available 'fishery name' values
 }
 \examples{
+\dontrun{
 head(fetch_fishery_names(), n = 10)
+}
 }
 \seealso{
 Other public_data: 

--- a/man/fishery_catchgroups.Rd
+++ b/man/fishery_catchgroups.Rd
@@ -22,7 +22,6 @@ Simple wrapper to query the vw_fishery_manager table.
 \seealso{
 Other internal_data: 
 \code{\link{connect_creel_db}()},
-\code{\link{fetch_data}()},
 \code{\link{fetch_db_table}()},
 \code{\link{fishery_catchgroups_obs}()}
 }

--- a/man/fishery_catchgroups.Rd
+++ b/man/fishery_catchgroups.Rd
@@ -4,7 +4,7 @@
 \alias{fishery_catchgroups}
 \title{Get 'fishery_catch_groups' view}
 \usage{
-fishery_catchgroups(conn, fishery_name = NULL, print = FALSE)
+fishery_catchgroups(conn = NULL, fishery_name = NULL, print = FALSE)
 }
 \arguments{
 \item{conn}{A valid database connection from \code{connect_creel_db()}}
@@ -22,6 +22,7 @@ Simple wrapper to query the vw_fishery_manager table.
 \seealso{
 Other internal_data: 
 \code{\link{connect_creel_db}()},
+\code{\link{fetch_data}()},
 \code{\link{fetch_db_table}()},
 \code{\link{fishery_catchgroups_obs}()}
 }

--- a/man/fishery_catchgroups_obs.Rd
+++ b/man/fishery_catchgroups_obs.Rd
@@ -34,7 +34,6 @@ The standard input for \code{data} is the list object returned by \code{\link[=f
 \seealso{
 Other internal_data: 
 \code{\link{connect_creel_db}()},
-\code{\link{fetch_data}()},
 \code{\link{fetch_db_table}()},
 \code{\link{fishery_catchgroups}()}
 }

--- a/man/fishery_catchgroups_obs.Rd
+++ b/man/fishery_catchgroups_obs.Rd
@@ -4,7 +4,7 @@
 \alias{fishery_catchgroups_obs}
 \title{Get observed catch groups for a fishery}
 \usage{
-fishery_catchgroups_obs(conn, data, include_zero = FALSE)
+fishery_catchgroups_obs(conn = NULL, data, include_zero = FALSE)
 }
 \arguments{
 \item{conn}{A valid database connection from \code{\link[=connect_creel_db]{connect_creel_db()}}.}
@@ -34,6 +34,7 @@ The standard input for \code{data} is the list object returned by \code{\link[=f
 \seealso{
 Other internal_data: 
 \code{\link{connect_creel_db}()},
+\code{\link{fetch_data}()},
 \code{\link{fetch_db_table}()},
 \code{\link{fishery_catchgroups}()}
 }

--- a/man/fishery_lut.Rd
+++ b/man/fishery_lut.Rd
@@ -4,7 +4,7 @@
 \alias{fishery_lut}
 \title{Get fishery lookup table}
 \usage{
-fishery_lut(conn)
+fishery_lut(conn = NULL)
 }
 \arguments{
 \item{conn}{A valid database connection from \code{connect_creel_db()}}

--- a/man/fishery_manager.Rd
+++ b/man/fishery_manager.Rd
@@ -4,7 +4,7 @@
 \alias{fishery_manager}
 \title{Get 'fishery manager' table}
 \usage{
-fishery_manager(conn, fishery_name = NULL)
+fishery_manager(conn = NULL, fishery_name = NULL)
 }
 \arguments{
 \item{conn}{A valid database connection from \code{connect_creel_db()}}

--- a/man/search_fishery_name.Rd
+++ b/man/search_fishery_name.Rd
@@ -16,8 +16,10 @@ Character vector of 'fishery_name' identifiers containing the partial value.
 Helps identify options for \code{fetch_dwg()}.
 }
 \examples{
+\dontrun{
 search_fishery_name("gamefish")
 search_fishery_name("Humptulips")
+}
 }
 \seealso{
 Other public_data: 

--- a/vignettes/creelutils.Rmd
+++ b/vignettes/creelutils.Rmd
@@ -43,7 +43,7 @@ For example, the *Skagit winter steelhead 2021* dataset contains effort counts, 
 
 The function `fetch_dwg` downloads creel data from data.wa.gov by Fishery Name and is the primary route for accessing a complete dataset from a fishery.
 
-```{r}
+```{r, eval = FALSE}
 library(creelutils)
 
 fishery_name <- "Skagit winter steelhead 2021"
@@ -59,7 +59,7 @@ colnames(dat$effort)
 
 The function `fetch_fishery_names()`, which has no arguments, returns a list of all fishery names in the creel database.
 
-```{r}
+```{r, eval = FALSE}
 fetch_fishery_names() |> head(n = 10)
 ```
 
@@ -67,7 +67,7 @@ fetch_fishery_names() |> head(n = 10)
 
 The function `search_fishery_name()` can accept a vector of characters or numbers and returns the fishery names with those values.
 
-```{r}
+```{r, eval = FALSE}
 # by water body
 search_fishery_name("Humptulips") |> head(n = 5)
 
@@ -86,7 +86,7 @@ This section covers operations that require the appropriate credentials and perm
 
 An internal connection to the Postgres creel database can be made using the `establish_db_con` function. When called a RStudio UI prompt will open for the user to enter their password. This requires the proper user credentials and setup on local computer. If this is your first time using this method, contact the package maintainer for assistance. 
 
-```{r}
+```{r, eval = FALSE}
 # con <- establish_db_con()
 ```
 


### PR DESCRIPTION
Adds the ability to call helper functions in `query_helpers.R` without providing an established connection via `connect_creel_db()`. If a `conn` arg is supplied it will use that connection; however, if one is not supplied the functions will open own their own connections to `prod`. This streamlines common read-only queries and handles users forgetting to supply a connection. See wdfw-fp/creelutils#21 for more info.