### PR TITLE
Fix/fetch data function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Suggests:
     gt,
     DBI,
     RPostgres,
+    bit64,
     crayon,
     dbplyr,
     jsonlite,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# creelutils (dev)
+
+* `fetch_data()`: Fixed internal (PostgreSQL) data path to produce type-identical
+  output to the external (Socrata) path. Adds `.standardize_types()` helper that
+  coerces `integer64`/`integer` columns to `numeric`, preventing `bit64::integer64`
+  from reaching rstan and resolving Stan BSS model "container is empty" crashes
+  when using database-sourced data.
+
+* Added `bit64` to Suggests.
+
 # creelutils 0.1.1
 
 * `establish_db_con()`: changed default `conn_type` from `"odbc"` to `"config"` 

--- a/R/fetch_data.R
+++ b/R/fetch_data.R
@@ -214,8 +214,14 @@ fetch_data <- function(
 #' Socrata CSV data parsed by `readr::read_csv()` returns `numeric` for integer
 #' columns, `POSIXct` for date columns, and `logical` for all-NA character
 #' columns. PostgreSQL returns proper `integer`, `integer64`, `Date`, and
-#' `character` types. This helper makes internal output identical to external
-#' so downstream pipelines work interchangeably.
+#' `character` types. This helper makes internal output type-identical to
+#' external so downstream pipelines (including Stan data blocks) work
+#' interchangeably.
+#'
+#' Both `integer64` (PostgreSQL bigint via bit64) and plain R `integer` columns
+#' are coerced to `numeric` (double) to match what `readr::read_csv()` returns.
+#' This also prevents `bit64::integer64` from reaching rstan, which rejects
+#' that class in Stan data blocks.
 #'
 #' Additionally drops columns that exist only in the internal DB views but are
 #' absent from the public Socrata mirrors.
@@ -252,7 +258,11 @@ fetch_data <- function(
     # Coerce column types to match readr::read_csv() output
     for (col in names(tbl)) {
       if (inherits(tbl[[col]], "integer64") || is.integer(tbl[[col]])) {
-        # integer / integer64 → numeric (readr returns doubles for integer CSV cols)
+        # integer64 / integer → numeric (double).
+        # readr::read_csv() returns doubles for all integer CSV columns, so
+        # both integer64 (PostgreSQL bigint via bit64) and plain R integer
+        # must become numeric to match. This also prevents bit64::integer64
+        # from reaching rstan, which rejects that class in Stan data blocks.
         tbl[[col]] <- as.numeric(tbl[[col]])
       } else if (inherits(tbl[[col]], "Date") &&
                  col == "event_date" &&

--- a/R/fetch_data.R
+++ b/R/fetch_data.R
@@ -276,10 +276,19 @@ fetch_data <- function(
     }
 
     # All-NA columns → logical. readr::read_csv() infers all-NA columns as
-    # logical regardless of the source type. Done as a second pass after
-    # integer→numeric coercion so converted columns are also caught.
+    # logical regardless of the source type, except for a few columns whose
+    # true schema type is character (see force_character_cols below).
+    # Second pass after int-num coercion so converted columns are also caught.
+    #
+    # NOTE: this heuristic is lossy for character columns that happen to be
+    # all-NA in a given fishery. force_character_cols is a stopgap; we should
+    # consider moving to an explicit expected-type schema map.
+    force_character_cols <- c("no_count_reason")
+
     for (col in names(tbl)) {
-      if (!is.logical(tbl[[col]]) && all(is.na(tbl[[col]]))) {
+      if (col %in% force_character_cols && all(is.na(tbl[[col]]))) {
+        tbl[[col]] <- as.character(tbl[[col]])
+      } else if (!is.logical(tbl[[col]]) && all(is.na(tbl[[col]]))) {
         tbl[[col]] <- as.logical(tbl[[col]])
       }
     }

--- a/R/fetch_data.R
+++ b/R/fetch_data.R
@@ -202,6 +202,81 @@ fetch_data <- function(
     result[["creel_event"]] <- fetch_db_table(conn, "creel", view_map[["creel_event"]], filter = event_filter)
   }
 
+  # Standardize types to match external (Socrata CSV) output ----
+  .standardize_types(result)
+}
+
+
+# Type standardization helper --------------------------------------------------------------------------------------
+
+#' Coerce internal (PostgreSQL) column types to match external (Socrata CSV) types
+#'
+#' Socrata CSV data parsed by `readr::read_csv()` returns `numeric` for integer
+#' columns, `POSIXct` for date columns, and `logical` for all-NA character
+#' columns. PostgreSQL returns proper `integer`, `integer64`, `Date`, and
+#' `character` types. This helper makes internal output identical to external
+#' so downstream pipelines work interchangeably.
+#'
+#' Additionally drops columns that exist only in the internal DB views but are
+#' absent from the public Socrata mirrors.
+#' @param result Named list of tibbles from `.fetch_data_internal()`
+#' @return Same structure with coerced column types
+#' @noRd
+.standardize_types <- function(result) {
+
+  # Columns present in internal DB views but absent from Socrata mirrors
+  internal_only_cols <- list(
+    ll              = c("water_body_code", "shape", "sort",
+                        "water_body_id_int", "obsolete_flag", "obsolete_date"),
+    interview       = c("best_location_id"),
+    fishery_manager = c("fishery_start_date", "fishery_end_date")
+  )
+
+  # Tables where event_date is POSIXct externally (Socrata returns timestamp);
+
+  # all others keep Date
+  posixct_event_date_tables <- c("closures", "creel_event")
+
+  # Character columns that readr parses as numeric (they look numeric in CSV)
+  char_to_numeric_cols <- c("llid", "crc_area", "catch_area_code")
+
+  for (tbl_name in names(result)) {
+    tbl <- result[[tbl_name]]
+    if (is.null(tbl)) next
+
+    # Drop internal-only columns
+    if (tbl_name %in% names(internal_only_cols)) {
+      tbl <- dplyr::select(tbl, -dplyr::any_of(internal_only_cols[[tbl_name]]))
+    }
+
+    # Coerce column types to match readr::read_csv() output
+    for (col in names(tbl)) {
+      if (inherits(tbl[[col]], "integer64") || is.integer(tbl[[col]])) {
+        # integer / integer64 → numeric (readr returns doubles for integer CSV cols)
+        tbl[[col]] <- as.numeric(tbl[[col]])
+      } else if (inherits(tbl[[col]], "Date") &&
+                 col == "event_date" &&
+                 tbl_name %in% posixct_event_date_tables) {
+        # Date → POSIXct only for closures/creel_event (Socrata returns timestamp)
+        tbl[[col]] <- as.POSIXct(as.character(tbl[[col]]), tz = "UTC")
+      } else if (is.character(tbl[[col]]) && col %in% char_to_numeric_cols) {
+        # Character → numeric (readr infers these as numeric from CSV)
+        tbl[[col]] <- suppressWarnings(as.numeric(tbl[[col]]))
+      }
+    }
+
+    # All-NA columns → logical. readr::read_csv() infers all-NA columns as
+    # logical regardless of the source type. Done as a second pass after
+    # integer→numeric coercion so converted columns are also caught.
+    for (col in names(tbl)) {
+      if (!is.logical(tbl[[col]]) && all(is.na(tbl[[col]]))) {
+        tbl[[col]] <- as.logical(tbl[[col]])
+      }
+    }
+
+    result[[tbl_name]] <- tbl
+  }
+
   result
 }
 


### PR DESCRIPTION
Summary
Fix fetch_data() so the internal (PostgreSQL) data path produces type-identical output to the external (Socrata) path, resolving Stan BSS model crashes when using database-sourced data.

Problem
Stan BSS model crashed with "container is empty" errors exclusively when using internal data. Root cause: PostgreSQL returns bit64::integer64 and integer types that rstan rejects, while the external path via readr::read_csv() returns numeric (double) for the same columns.

Changes
[fetch_data.R](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Added .standardize_types() helper called at the end of .fetch_data_internal():

integer64/integer → numeric (prevents rstan rejection)
Date → POSIXct for timestamp tables (closures, creel_event)
character → numeric for numeric-looking fields (llid, crc_area, catch_area_code)
All-NA columns → logical (matches readr inference)
Drops internal-only columns absent from Socrata mirrors
[DESCRIPTION](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Added bit64 to Suggests.

[test-standardize_types.R](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — 33 unit tests covering type coercion, value preservation, and downstream rstan compatibility. ** stashed this away until new work is opened up to build in unit testing