### PR TITLE
Docs/socrata api instructions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: creelutils
 Title: Utility Functions for Interacting with Freshwater Creel Data
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
     person("Colt", "Holley", email = "colt.holley@dfw.wa.gov", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-4172-4331")),
     person("Kale", "Bentley", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# creelutils 0.2.1
+
+*Released 2026-08-20*
+
+* Add instructions to `fetch_data()` for setting up optional Socrata API token for <https://data.wa.gov> to prevent occasional throttling.
+
 # creelutils 0.2.0
 
 *Released 2026-06-02*

--- a/R/fetch_data.R
+++ b/R/fetch_data.R
@@ -39,6 +39,26 @@
 #' yet published to data.wa.gov; requesting it returns `NULL` with an
 #' informative message.
 #'
+#' ## (Optional) Socrata SODA API Token Setup
+#' <https://www.data.wa.gov/> can occasionally throttle data requests.
+#' This rate limitation is intermittent and may cause `fetch_data` to fail.
+#' Each user may register for an app token that will prevent this from occurring.
+#' It only takes a couple of minutes.
+#'
+#' Step 1: Register for an app token
+#'  - Create a free account at data.wa.gov —> click Sign In -> Sign Up in the top right corner
+#'  - Once logged in, navigate to your profile -> Developer Settings -> Create New App Token
+#'  - Fill in Application Name (e.g., CreelEstimates) and Description. All other fields can be left blank
+#'  - Click Save and copy the App Token value (not the Secret Token)
+#'
+#'  Step 2: Store the token in your R environment
+#'  - Open your .Renviron file: `usethis::edit_r_environ()`
+#'  - Add the following line, then save and close the file: `SOCRATA_APP_TOKEN=your_token_here`
+#'  - Restart R, then confirm the token is accessible: `Sys.getenv("SOCRATA_APP_TOKEN")`
+#'    - Should return your token, not ""
+#'
+#'  WARNING: `Renviron` is stored locally and is not tracked by git.
+#'
 #' @family data
 #' @importFrom rlang .data
 #' @export

--- a/man/fetch_data.Rd
+++ b/man/fetch_data.Rd
@@ -59,6 +59,34 @@ connection is required or referenced. The \code{model_catch_group} view is not
 yet published to data.wa.gov; requesting it returns \code{NULL} with an
 informative message.
 }
+
+\subsection{(Optional) Socrata SODA API Token Setup}{
+
+\url{https://www.data.wa.gov/} can occasionally throttle data requests.
+This rate limitation is intermittent and may cause \code{fetch_data} to fail.
+Each user may register for an app token that will prevent this from occurring.
+It only takes a couple of minutes.
+
+Step 1: Register for an app token
+\itemize{
+\item Create a free account at data.wa.gov —> click Sign In -> Sign Up in the top right corner
+\item Once logged in, navigate to your profile -> Developer Settings -> Create New App Token
+\item Fill in Application Name (e.g., CreelEstimates) and Description. All other fields can be left blank
+\item Click Save and copy the App Token value (not the Secret Token)
+}
+
+Step 2: Store the token in your R environment
+\itemize{
+\item Open your .Renviron file: \code{usethis::edit_r_environ()}
+\item Add the following line, then save and close the file: \code{SOCRATA_APP_TOKEN=your_token_here}
+\item Restart R, then confirm the token is accessible: \code{Sys.getenv("SOCRATA_APP_TOKEN")}
+\itemize{
+\item Should return your token, not ""
+}
+}
+
+WARNING: \code{Renviron} is stored locally and is not tracked by git.
+}
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Add instructions to `fetch_data()` for setting up optional Socrata API token for <https://data.wa.gov> to prevent occasional throttling.